### PR TITLE
[squid:S2095] Resources should be closed

### DIFF
--- a/app/src/main/java/dong/lan/tuyi/util/PhotoUtil.java
+++ b/app/src/main/java/dong/lan/tuyi/util/PhotoUtil.java
@@ -452,6 +452,8 @@ public class PhotoUtil {
 	 */
 	public static Bitmap getbitmapAndwrite(String imageUri) {
 		Bitmap bitmap = null;
+		InputStream is = null;
+		BufferedOutputStream bos = null;
 		try {
 			// 显示网络上的图片
 			URL myFileUrl = new URL(imageUri);
@@ -460,9 +462,8 @@ public class PhotoUtil {
 			conn.setDoInput(true);
 			conn.connect();
 
-			InputStream is = conn.getInputStream();
+			is = conn.getInputStream();
 			File cacheFile = FileUilt.getCacheFile(imageUri);
-			BufferedOutputStream bos = null;
 			bos = new BufferedOutputStream(new FileOutputStream(cacheFile));
 			Log.i(TAG, "write file to " + cacheFile.getCanonicalPath());
 
@@ -473,8 +474,6 @@ public class PhotoUtil {
 				bos.write(buf, 0, len);
 			}
 
-			is.close();
-			bos.close();
 
 			// 从本地加载图片
 			bitmap = BitmapFactory.decodeFile(cacheFile.getCanonicalPath());
@@ -482,6 +481,19 @@ public class PhotoUtil {
 
 		} catch (IOException e) {
 			e.printStackTrace();
+		} finally {
+			try {
+				if (is != null)
+					is.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			try {
+				if (bos != null)
+					bos.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 		}
 		return bitmap;
 	}

--- a/app/src/main/java/dong/lan/tuyi/utils/ImgPlayAsyn.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/ImgPlayAsyn.java
@@ -59,6 +59,8 @@ public class ImgPlayAsyn extends AsyncTask<String,Integer,Bitmap> {
                 e.printStackTrace();
             }
         } else {
+            InputStream is = null;
+            BufferedOutputStream bos = null;
             try {
                 // 显示网络上的图片
                 URL myFileUrl = new URL(params[0]);
@@ -66,9 +68,8 @@ public class ImgPlayAsyn extends AsyncTask<String,Integer,Bitmap> {
                         .openConnection();
                 conn.setDoInput(true);
                 conn.connect();
-                InputStream is = conn.getInputStream();
+                is = conn.getInputStream();
                 cacheFile = FileUilt.getCacheFile(params[0]);
-                BufferedOutputStream bos = null;
                 bos = new BufferedOutputStream(new FileOutputStream(cacheFile));
                 byte[] buf = new byte[1024];
                 int len = 0;
@@ -77,13 +78,24 @@ public class ImgPlayAsyn extends AsyncTask<String,Integer,Bitmap> {
                     bos.write(buf, 0, len);
                 }
 
-                is.close();
-                bos.close();
                 // 从本地加载图片
                 bitmap = BitmapFactory.decodeFile(cacheFile.getCanonicalPath());
 
             } catch (IOException e) {
                 e.printStackTrace();
+            } finally {
+                try {
+                    if (is != null)
+                        is.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                try {
+                    if (bos != null)
+                        bos.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
         return bitmap;

--- a/app/src/main/java/dong/lan/tuyi/utils/MyImageAsyn.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/MyImageAsyn.java
@@ -81,6 +81,8 @@ public class MyImageAsyn extends AsyncTask<String,Integer,Bitmap> {
                 e.printStackTrace();
             }
         } else {
+            InputStream is = null;
+            BufferedOutputStream bos = null;
             try {
                 // 显示网络上的图片
                 URL myFileUrl = new URL(params[0]);
@@ -88,9 +90,8 @@ public class MyImageAsyn extends AsyncTask<String,Integer,Bitmap> {
                         .openConnection();
                 conn.setDoInput(true);
                 conn.connect();
-                InputStream is = conn.getInputStream();
+                is = conn.getInputStream();
                 cacheFile = FileUilt.getCacheFile(params[0]);
-                BufferedOutputStream bos = null;
                 bos = new BufferedOutputStream(new FileOutputStream(cacheFile));
                 byte[] buf = new byte[1024];
                 int len = 0;
@@ -99,13 +100,24 @@ public class MyImageAsyn extends AsyncTask<String,Integer,Bitmap> {
                     bos.write(buf, 0, len);
                 }
 
-                is.close();
-                bos.close();
                 // 从本地加载图片
                 bitmap = BitmapFactory.decodeFile(cacheFile.getCanonicalPath());
 
             } catch (IOException e) {
                 e.printStackTrace();
+            } finally {
+                try {
+                    if (is != null)
+                        is.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                try {
+                    if (bos != null)
+                        bos.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
         return bitmap;

--- a/app/src/main/java/dong/lan/tuyi/utils/MyImageDownload.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/MyImageDownload.java
@@ -50,6 +50,8 @@ public class MyImageDownload extends AsyncTask<String,Integer,Integer> {
             uriList.add(uri);
             return 1;
         } else {
+            InputStream is = null;
+            BufferedOutputStream bos = null;
             try {
                 // 显示网络上的图片
                 URL myFileUrl = new URL(params[0]);
@@ -58,9 +60,8 @@ public class MyImageDownload extends AsyncTask<String,Integer,Integer> {
                 conn.setDoInput(true);
                 conn.connect();
 
-                InputStream is = conn.getInputStream();
+                is = conn.getInputStream();
                 cacheFile = FileUilt.getCacheFile(params[0]);
-                BufferedOutputStream bos = null;
                 bos = new BufferedOutputStream(new FileOutputStream(cacheFile));
                 byte[] buf = new byte[1024];
                 int len = 0;
@@ -69,8 +70,6 @@ public class MyImageDownload extends AsyncTask<String,Integer,Integer> {
                     bos.write(buf, 0, len);
                 }
 
-                is.close();
-                bos.close();
                 Uri uri = Uri.fromFile(cacheFile);
                 uriList.add(uri);
                 Config.print(uri.toString());
@@ -80,6 +79,19 @@ public class MyImageDownload extends AsyncTask<String,Integer,Integer> {
 
             } catch (IOException e) {
                 e.printStackTrace();
+            } finally {
+                try {
+                    if (is != null)
+                        is.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                try {
+                    if (bos != null)
+                        bos.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
         return 1;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Abdelghany.
