### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/app/src/main/java/dong/lan/tuyi/util/AsynImageLoader.java
+++ b/app/src/main/java/dong/lan/tuyi/util/AsynImageLoader.java
@@ -182,6 +182,8 @@ private static AsynImageLoader instance;
 
         @Override
         public boolean equals(Object o) {
+            if (o == null)
+                return false;
             Task task = (Task) o;
             return task.path.equals(path);
         }

--- a/app/src/main/java/dong/lan/tuyi/util/PhotoUtil.java
+++ b/app/src/main/java/dong/lan/tuyi/util/PhotoUtil.java
@@ -384,16 +384,14 @@ public class PhotoUtil {
 	 */
 	public static BitmapDrawable getcontentPic(String imageUri) {
 		URL imgUrl = null;
-		try {
-			imgUrl = new URL(imageUri);
-		} catch (MalformedURLException e1) {
-			e1.printStackTrace();
-		}
 		BitmapDrawable icon = null;
 		try {
+			imgUrl = new URL(imageUri);
 			HttpURLConnection hp = (HttpURLConnection) imgUrl.openConnection();
 			icon = new BitmapDrawable(hp.getInputStream());// 将输入流转换成bitmap
 			hp.disconnect();// 关闭连接
+		} catch (MalformedURLException e1) {
+			e1.printStackTrace();
 		} catch (Exception e) {
 		}
 		return icon;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
