### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/dong/lan/tuyi/adapter/ViewHolder.java
+++ b/app/src/main/java/dong/lan/tuyi/adapter/ViewHolder.java
@@ -7,6 +7,9 @@ import android.view.View;
   */
 @SuppressWarnings("unchecked")
 public class ViewHolder {
+	private ViewHolder() {
+	}
+
 	public static <T extends View> T get(View view, int id) {
 		SparseArray<View> viewHolder = (SparseArray<View>) view.getTag();
 		if (viewHolder == null) {

--- a/app/src/main/java/dong/lan/tuyi/util/AnimationUtil.java
+++ b/app/src/main/java/dong/lan/tuyi/util/AnimationUtil.java
@@ -30,6 +30,9 @@ public class AnimationUtil {
 	public  static AlphaAnimation alphaA = new AlphaAnimation(1f,0.6f);
 	public static  AlphaAnimation alphaB = new AlphaAnimation(0.4f,1f);
 
+	private AnimationUtil() {
+	}
+
 	public  static  AlphaAnimation alphaA()
 	{
 		alphaA.setDuration(400);

--- a/app/src/main/java/dong/lan/tuyi/util/FileUilt.java
+++ b/app/src/main/java/dong/lan/tuyi/util/FileUilt.java
@@ -12,6 +12,9 @@ import java.io.IOException;
 public class FileUilt {
     private static final String TAG = "FileUtil";
 
+    private FileUilt() {
+    }
+
     public static File getCacheFile(String imageUri){
         File cacheFile = null;
         try {

--- a/app/src/main/java/dong/lan/tuyi/util/PhotoUtil.java
+++ b/app/src/main/java/dong/lan/tuyi/util/PhotoUtil.java
@@ -40,6 +40,9 @@ public class PhotoUtil {
 
 	private static final String TAG = "PicUtil";
 
+	private PhotoUtil() {
+	}
+
 
 	/**
 	 * 回收垃圾 recycle

--- a/app/src/main/java/dong/lan/tuyi/utils/CommonUtils.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/CommonUtils.java
@@ -30,7 +30,11 @@ import dong.lan.tuyi.R;
 
 public class CommonUtils {
 	private static final String TAG = "CommonUtils";
-	/**
+
+    private CommonUtils() {
+    }
+
+    /**
 	 * 检测网络是否可用
 	 * 
 	 * @param context

--- a/app/src/main/java/dong/lan/tuyi/utils/DateUtils.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/DateUtils.java
@@ -16,6 +16,9 @@ public class DateUtils {
 
     private static final long INTERVAL_IN_MILLISECONDS = 30 * 1000;
 
+    private DateUtils() {
+    }
+
     public static String getTimestampString(Date messageDate) {
         Locale curLocale = HXSDKHelper.getInstance().getAppContext().getResources().getConfiguration().locale;
         

--- a/app/src/main/java/dong/lan/tuyi/utils/ImageHelper.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/ImageHelper.java
@@ -17,6 +17,9 @@ import android.text.TextPaint;
 public class ImageHelper {
 
 
+    private ImageHelper() {
+    }
+
     public static  Bitmap handleColorMatrixs(Bitmap bitmap,float colorMatrixs[]) {
         Bitmap bmp = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
         ColorMatrix matrix = new ColorMatrix();

--- a/app/src/main/java/dong/lan/tuyi/utils/ImageUtils.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/ImageUtils.java
@@ -17,6 +17,8 @@ import com.easemob.util.EMLog;
 import com.easemob.util.PathUtil;
 
 public class ImageUtils {
+	private ImageUtils() {
+	}
 //	public static String getThumbnailImagePath(String imagePath) {
 //		String path = imagePath.substring(0, imagePath.lastIndexOf("/") + 1);
 //		path += "th" + imagePath.substring(imagePath.lastIndexOf("/") + 1, imagePath.length());

--- a/app/src/main/java/dong/lan/tuyi/utils/InputTools.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/InputTools.java
@@ -12,6 +12,9 @@ import java.util.TimerTask;
 
 public class InputTools {
 
+    private InputTools() {
+    }
+
     public static void hideSoftKeyboard(Activity activity) {
         if (activity.getWindow().getAttributes().softInputMode != WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN) {
             if (activity.getCurrentFocus() != null)

--- a/app/src/main/java/dong/lan/tuyi/utils/SmileUtils.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/SmileUtils.java
@@ -186,6 +186,9 @@ public class SmileUtils {
 
 	}
 
+	private SmileUtils() {
+	}
+
 	private static void addPattern(Map<Pattern, Integer> map, String smile,
 	        int resource) {
 	    map.put(Pattern.compile(Pattern.quote(smile)), resource);

--- a/app/src/main/java/dong/lan/tuyi/utils/TimeUtil.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/TimeUtil.java
@@ -27,6 +27,9 @@ public class TimeUtil {
 	private static final int HOUR = 60 * 60;// 小时
 	private static final int MINUTE = 60;// 分钟
 
+	private TimeUtil() {
+	}
+
 	/**
 	 * 根据时间戳获取描述性时间，如3分钟前，1天前
 	 * 

--- a/app/src/main/java/dong/lan/tuyi/utils/UserUtils.java
+++ b/app/src/main/java/dong/lan/tuyi/utils/UserUtils.java
@@ -22,6 +22,9 @@ import dong.lan.tuyi.domain.User;
 
 
 public class UserUtils {
+    private UserUtils() {
+    }
+
     /**
      * 根据username获取相应user，由于demo没有真实的用户数据，这里给的模拟的数据；
      * @param username


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
