### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/EaseUI/README.md
+++ b/EaseUI/README.md
@@ -1,5 +1,5 @@
 # easeui
-####EaseUI是一个基于环信sdk的UI库，封装了IM功能常用的控件、fragment等等。此项目包含一个简单使用的demo：simpledemo，开发者可导出查看。
-####github上的代码不包含环信sdk，clone使用时需要把环信sdk所需的jar包，so等等拷贝进来。
+#### EaseUI是一个基于环信sdk的UI库，封装了IM功能常用的控件、fragment等等。此项目包含一个简单使用的demo：simpledemo，开发者可导出查看。
+#### github上的代码不包含环信sdk，clone使用时需要把环信sdk所需的jar包，so等等拷贝进来。
 
 > easeui文档地址：http://docs.easemob.com/doku.php?id=start:200androidcleintintegration:135easeuiuseguide

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 
 
-##未合并的修改请前往  [newTuyi](https://github.com/donlan/Tuyi/tree/newTuyi)
+## 未合并的修改请前往  [newTuyi](https://github.com/donlan/Tuyi/tree/newTuyi)
 
 ## Click  [newTuyi](https://github.com/donlan/Tuyi/tree/newTuyi) to see the latest merge 
 ___

--- a/redpacketlibrary/README.md
+++ b/redpacketlibrary/README.md
@@ -17,7 +17,7 @@
 
 ## 3. 集成步骤
 
-###3.1 添加对红包工程的依赖
+### 3.1 添加对红包工程的依赖
 * ChatDemo的build.gradle中
 
 ```
@@ -37,7 +37,7 @@
 include ':EaseUI', ':redpacketlibrary'
 
 ```
-###3.2 ChatDemo清单文件中注册红包相关组件
+### 3.2 ChatDemo清单文件中注册红包相关组件
 ```
 
         <uses-sdk
@@ -106,7 +106,7 @@ include ':EaseUI', ':redpacketlibrary'
         <!--红包相关界面end-->    
 ```
 
-###3.3 初始化红包上下文
+### 3.3 初始化红包上下文
 * DemoApplication中初始化红包上下文
 
 ```
@@ -280,7 +280,7 @@ include ':EaseUI', ':redpacketlibrary'
         }
     }
 ```
-###3.5 群红包领取回执的全局处理
+### 3.5 群红包领取回执的全局处理
 
 
 * DemoHelper中
@@ -344,7 +344,7 @@ include ':EaseUI', ':redpacketlibrary'
         
 ```
 
-###3.6 ConversationListFragment中对红包回执消息的处理
+### 3.6 ConversationListFragment中对红包回执消息的处理
 
 ```
    import com.easemob.redpacketui.RedPacketConstant;
@@ -377,7 +377,7 @@ include ':EaseUI', ':redpacketlibrary'
     }
 ```
 
-###3.7 添加零钱页的入口
+### 3.7 添加零钱页的入口
 
 * 在需要添加零钱的页面调用下面的方法
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
